### PR TITLE
Update remus100.py

### DIFF
--- a/src/python_vehicle_simulator/vehicles/remus100.py
+++ b/src/python_vehicle_simulator/vehicles/remus100.py
@@ -367,7 +367,7 @@ class remus100:
         Y_r = -0.5 * self.rho * U_rh**2 * self.A_r * self.CL_delta_r * delta_r
 
         # Stern-plane heave force
-        Z_s = -0.5 * self.rho * U_rv**2 * self.A_s * self.CL_delta_s * delta_s
+        Z_s = 0.5 * self.rho * U_rv**2 * self.A_s * self.CL_delta_s * delta_s
 
         # Generalized force vector
         tau = np.array([
@@ -375,7 +375,7 @@ class remus100:
             Y_r, 
             Z_s,
             K_prop / 10,   # scaled down by a factor of 10 to match exp. results
-            self.x_s * Z_s,
+            -1 * self.x_s * Z_s,
             self.x_r * Y_r
             ], float)
     


### PR DESCRIPTION
If positive deflection of stern plane pitches vehicle up the calculations are represented more accurately by this:

Positive deflection -> Positive Z force (Z-down)
Negative X distance and Positive Z force  -> Positive Y moment (right hand rule) positive Y moment -> pitches vehicle up 

The small error is in the cross product of the x distance and the applied force. My = [-x, 0,0] X [0,0,z] = [0, x*z, 0] where the Y moment is positive for a positive z force and a negative x distance. 

The simulation seems to run the same with this small change.