### PR TITLE
Use relative speed for the propeller advance speed in remus100

### DIFF
--- a/src/python_vehicle_simulator/vehicles/remus100.py
+++ b/src/python_vehicle_simulator/vehicles/remus100.py
@@ -258,7 +258,6 @@ class remus100:
         Dnu_c = np.array([nu[5]*v_c, -nu[5]*u_c, 0, 0, 0, 0],float) # derivative
         nu_r = nu - nu_c                               # relative velocity        
         alpha = math.atan2( nu_r[2], nu_r[0] )         # angle of attack 
-        U = math.sqrt(nu[0]**2 + nu[1]**2 + nu[2]**2)  # vehicle speed
         U_r = math.sqrt(nu_r[0]**2 + nu_r[1]**2 + nu_r[2]**2)  # relative speed
 
         # Commands and actual control signals
@@ -281,11 +280,11 @@ class remus100:
             n = np.sign(n) * self.nMax       
         
         # Propeller coeffs. KT and KQ are computed as a function of advance no.
-        # Ja = Va/(n*D_prop) where Va = (1-w)*U = 0.944 * U; Allen et al. (2000)
+        # Ja = Va/(n*D_prop) where Va = (1-w)*U_r = 0.944 * U_r; Allen et al. (2000)
         D_prop = 0.14   # propeller diameter corresponding to 5.5 inches
         t_prop = 0.1    # thrust deduction number
         n_rps = n / 60  # propeller revolution (rps) 
-        Va = 0.944 * U  # advance speed (m/s)
+        Va = 0.944 * U_r  # advance speed (m/s)
 
         # Ja_max = 0.944 * 2.5 / (0.14 * 1525/60) = 0.6632
         Ja_max = 0.6632

--- a/tests/test_propeller_advance_speed.py
+++ b/tests/test_propeller_advance_speed.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+The pytest for 'test_propeller_advance_speed.py' can be run in the terminal using:
+1) cd <path of the Python Vehicle Simulator installation>
+2) pytest -k propeller -v
+"""
+
+import numpy as np
+from python_vehicle_simulator.vehicles import remus100
+
+
+def nu_dot(vehicle, eta, nu, u_actual, u_control, dt):
+    """Recover nu_dot from one forward-Euler step of dynamics()."""
+    nu_out, _ = vehicle.dynamics(eta.copy(), nu.copy(), u_actual.copy(), u_control, dt)
+    return (nu_out - nu) / dt
+
+
+def test_propulsion_depends_on_relative_flow_only():
+    """Hydrodynamic and propulsion forces arise from the flow past the hull
+    and propeller, so they can depend only on the relative velocity nu_r,
+    never on the ground-relative velocity. Two cases with identical nu_r --
+    still water at u = 1.5 m/s, and a 0.5 m/s head current with u = 1.0 m/s
+    -- must therefore produce identical accelerations. The yaw rate is zero
+    so the rotating-frame current derivative Dnu_c vanishes and the full
+    nu_dot is directly comparable. The current is 0.5 (exact in binary
+    floating point) so nu - nu_c reproduces nu_r bitwise."""
+    dt = 0.02
+    eta = np.zeros(6)
+    u_actual = np.array([0.05, -0.03, 1200.0])
+    u_control = np.array([0.05, -0.03, 1200.0])
+    nu_r = np.array([1.5, 0.1, 0.2, 0.05, 0.1, 0.0])
+
+    still_water = remus100()
+    a = nu_dot(still_water, eta, nu_r, u_actual, u_control, dt)
+
+    current = 0.5
+    head_current = remus100("stepInput", 0, 0, 0, current, 180)
+    nu = nu_r + np.array([-current, 0, 0, 0, 0, 0])
+    b = nu_dot(head_current, eta, nu, u_actual, u_control, dt)
+
+    assert np.allclose(a, b, atol=1e-10)


### PR DESCRIPTION
The propeller model computes `Va = 0.944 * U` with `U` taken from `nu`, i.e. the ground-relative speed. Advance speed is a through-water quantity: the wake-fraction relation `Va = (1-w)*U`, with `1-w = 0.944` from Allen, Vorus & Prestero (OCEANS 2000, Table 5), is defined with respect to the hull's speed through the water (tow-tank data; onset flow including the hull boundary layer). With an ocean current present, the through-water speed is `U_r`, and using `U` makes thrust and torque depend on ground speed while the rest of the model is expressed in `nu_r`. In still water `U = U_r`, which is why the difference is invisible without currents.

This PR computes `Va` from `U_r` and removes the now-unused `U`.

`tests/test_propeller_advance_speed.py` checks the underlying invariance: two cases with identical relative flow, still water at u = 1.5 m/s, and a 0.5 m/s head current at u = 1.0 m/s, must produce identical accelerations (yaw rate is zero, so the rotating-frame current term vanishes). The test fails on the present code (the thrust differs by roughly 13 N between the two cases) and passes with the fix.