### PR TITLE
Fix strip-theory integration in crossFlowDrag overshooting the hull length

### DIFF
--- a/src/python_vehicle_simulator/lib/gnc.py
+++ b/src/python_vehicle_simulator/lib/gnc.py
@@ -212,14 +212,14 @@ def crossFlowDrag(L,B,T,nu_r):
     rho = 1026               # density of water
     n = 20                   # number of strips
 
-    dx = L/20             
+    dx = L/n
     Cd_2D = Hoerner(B,T)    # 2D drag coefficient based on Hoerner's curve
 
     Yh = 0
     Nh = 0
-    xL = -L/2
+    xL = -L/2 + dx/2
     
-    for i in range(0,n+1):
+    for i in range(0,n):
         v_r = nu_r[1]             # relative sway velocity
         r = nu_r[5]               # yaw rate
         Ucf = abs(v_r + xL * r) * (v_r + xL * r)

--- a/tests/test_crossflow_drag.py
+++ b/tests/test_crossflow_drag.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+The pytest for 'test_crossflow_drag.py' can be run in the terminal using:
+1) cd <path of the Python Vehicle Simulator installation>
+2) pytest -k crossflow -v
+"""
+
+import numpy as np
+import math
+from python_vehicle_simulator.lib.gnc import crossFlowDrag, Hoerner
+
+RHO = 1026  # water density used internally by crossFlowDrag
+
+
+def test_pure_sway_force_matches_analytic_integral():
+    """In pure sway (v != 0, r = 0) the cross-flow term |v + x*r|(v + x*r)
+    reduces to the constant |v|v, so the strip integral has the closed form
+    Y = -1/2 * rho * T * Cd_2D * |v|v * L. A quadrature spanning exactly
+    [-L/2, L/2] reproduces this to machine precision."""
+    L, B, T = 1.6, 0.19, 0.19
+    v = 0.8
+    nu_r = np.array([0, v, 0, 0, 0, 0], float)
+
+    Y_true = -0.5 * RHO * T * Hoerner(B, T) * abs(v) * v * L
+    tau = crossFlowDrag(L, B, T, nu_r)
+
+    assert math.isclose(tau[1], Y_true, rel_tol=1e-9)
+
+
+def test_pure_yaw_moment_matches_analytic_integral():
+    """In pure yaw (v = 0, r != 0) the sway integrand |x*r|(x*r) is odd in x,
+    so the net sway force vanishes by symmetry, while the moment integrand
+    x * |x*r|(x*r) = |r|r * |x|^3 gives the closed form
+    N = -1/2 * rho * T * Cd_2D * |r|r * integral(|x|^3) = -... * L^4/32.
+    The 1% tolerance covers the midpoint-rule discretization error
+    (about 0.5% at n = 20, dominated by the |x|^3 kink at x = 0)."""
+    L, B, T = 1.6, 0.19, 0.19
+    r = 0.5
+    nu_r = np.array([0, 0, 0, 0, 0, r], float)
+
+    N_true = -0.5 * RHO * T * Hoerner(B, T) * abs(r) * r * L**4 / 32
+    tau = crossFlowDrag(L, B, T, nu_r)
+
+    assert abs(tau[1]) < 1e-9
+    assert math.isclose(tau[5], N_true, rel_tol=0.01)


### PR DESCRIPTION
`crossFlowDrag` sums `n+1 = 21` strips, each weighted `dx = L/20`, so the strip-theory integral effectively spans `1.05*L` instead of `[-L/2, L/2]`. This biases the pure-sway cross-flow force by about +5% and the pure-yaw cross-flow moment by about +21% (the moment integrand `|x|^3` is endpoint-heavy, so the double-counted hull ends dominate).

This PR switches the loop to the midpoint rule over `n` strips spanning exactly `[-L/2, L/2]`, and derives `dx` from `n` instead of hardcoding `L/20`.

`tests/test_crossflow_drag.py` checks the two closed-form cases:
- pure sway: the integrand is constant, so `Y = -1/2*rho*T*Cd_2D*|v|v*L` exactly (machine-precision tolerance);
- pure yaw: `N = -1/2*rho*T*Cd_2D*|r|r*L^4/32`, with a 1% tolerance covering the midpoint-rule discretization error (~0.5% at n = 20).

Both tests fail on the current code (+5% / +21%) and pass with the fix.